### PR TITLE
adding docker image, using multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:10.19.0-stretch-slim as build
+
+WORKDIR /src/app
+
+COPY . .
+
+RUN apt update && apt install -y python3-dev build-essential
+
+RUN yarn install
+
+FROM node:10.19.0-alpine AS production
+
+WORKDIR /src/app
+
+COPY --from=build /src/app .
+
+ENTRYPOINT ["yarn", "start"]


### PR DESCRIPTION
- using node:10.19.0-alpine as base image
- image size around 400 MB (half the size of stretch-slim)
test command: 
```
docker build  --tag some-image-name .
docker run  -p 3000:3000 --env-file=.env -d some-image-name
curl localhost:3000
```